### PR TITLE
Fix Bitmex rest api calls with parameters

### DIFF
--- a/lib/bitmex.rb
+++ b/lib/bitmex.rb
@@ -28,22 +28,26 @@ module Bitmex
   TESTNET_HOST = 'testnet.bitmex.com'.freeze
   MAINNET_HOST = 'www.bitmex.com'.freeze
 
-  def self.signature(api_secret, verb, path, expires, params)
-    params = '' if params.nil?
-    params = params.to_s unless params.is_a? String
+  def self.signature(api_secret, verb, path, expires, body, query)
+    body = '' if body.nil?
+    body = body.to_s unless body.is_a? String
 
-    data = verb + path + expires.to_s + params
+    if query != nil && query.is_a?(Hash) && !query.empty?
+      path += "?#{URI.encode_www_form(query)}"
+    end
+
+    data = verb + path + expires.to_s + body
     OpenSSL::HMAC.hexdigest 'SHA256', api_secret, data
   end
 
-  def self.headers(api_key, api_secret, verb, path, body)
+  def self.headers(api_key, api_secret, verb, path, body, query)
     return {} unless api_key || api_secret
 
     expires = Time.now.utc.to_i + 60
     {
       'api-expires' => expires.to_s,
       'api-key' => api_key,
-      'api-signature' => Bitmex.signature(api_secret, verb, path, expires, body)
+      'api-signature' => Bitmex.signature(api_secret, verb, path, expires, body, query)
     }
   end
 end

--- a/lib/bitmex/rest.rb
+++ b/lib/bitmex/rest.rb
@@ -29,7 +29,7 @@ module Bitmex
 
       options = {}
       options[:query] = params unless params.empty?
-      options[:headers] = rest_headers 'GET', path, '' if auth
+      options[:headers] = rest_headers 'GET', path, '', params if auth
 
       response = self.class.get "#{domain_url}#{path}", options
       block_given? ? yield(response) : response_handler(response)
@@ -40,7 +40,7 @@ module Bitmex
 
       options = {}
       options[:body] = body
-      options[:headers] = rest_headers 'PUT', path, body, json: json if auth
+      options[:headers] = rest_headers 'PUT', path, body, params, json: json if auth
 
       response = self.class.put "#{domain_url}#{path}", options
       block_given? ? yield(response) : response_handler(response)
@@ -51,7 +51,7 @@ module Bitmex
 
       options = {}
       options[:body] = body
-      options[:headers] = rest_headers 'POST', path, body, json: json if auth
+      options[:headers] = rest_headers 'POST', path, body, params, json: json if auth
 
       response = self.class.post "#{domain_url}#{path}", options
       block_given? ? yield(response) : response_handler(response)
@@ -62,7 +62,7 @@ module Bitmex
 
       options = {}
       options[:body] = body
-      options[:headers] = rest_headers 'DELETE', path, body, json: json if auth
+      options[:headers] = rest_headers 'DELETE', path, body, params, json: json if auth
 
       response = self.class.delete "#{domain_url}#{path}", options
       block_given? ? yield(response) : response_handler(response)
@@ -72,8 +72,8 @@ module Bitmex
       "/api/v1/#{resource}/#{action}"
     end
 
-    def rest_headers(verb, path, body, json: true)
-      headers = headers verb, path, body
+    def rest_headers(verb, path, body, query, json: true)
+      headers = headers verb, path, body, query
       if json
         headers['Content-Type'] = 'application/json'
       else
@@ -82,8 +82,8 @@ module Bitmex
       headers
     end
 
-    def headers(verb, path, body)
-      Bitmex.headers api_key, api_secret, verb, path, body
+    def headers(verb, path, body, query)
+      Bitmex.headers api_key, api_secret, verb, path, body, query
     end
 
     def response_handler(response)


### PR DESCRIPTION
Whenever we made an http call with a query string (parameter) we would
receive a:

"Invalid signature" error message from Bitmex's api

Since we must include the query string on the url path, in order to
calculate the request signature.

See:

https://www.bitmex.com/app/apiKeysUsage